### PR TITLE
fix #111

### DIFF
--- a/server/middlewares/api_proxy.js
+++ b/server/middlewares/api_proxy.js
@@ -1,3 +1,4 @@
+const Url = require('url');
 const hpm = require('http-proxy-middleware');
 const _ = require('lodash');
 
@@ -75,9 +76,9 @@ module.exports = function (path, dest) {
       const urlPath = /\/$/.test(req.path) ? req.path.replace(/\/$/, '') : req.path;
 
       if (proxyRes.statusCode === 301) {
-        let orgLocation = proxyRes.headers['location'];
-        if (orgLocation && orgLocation.includes('/api/board')) {
-          proxyRes.headers['location'] = `${config.origin}${orgLocation.substring(orgLocation.indexOf('/board'))}`;
+        const orgLocationUrl = Url.parse(proxyRes.headers['location']);
+        if (orgLocationUrl.pathname.includes('/api/board')) {
+          proxyRes.headers['location'] = `${config.origin}${orgLocationUrl.pathname}`;
         }
       }
 


### PR DESCRIPTION
api proxy로직에서 api응답이 3xx일때 최종 응답 location url에서 /api부분을 누락시킴.
ajax응답 location url을 웹 페이지 url로 보내게 되어,
브라우저에서 리디렉션으로 재호출될때 json응답을 못받아 "서버가 이상합니다" 출력하게됨.